### PR TITLE
Support to disable backup of transaction logs (GH-21)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV DB_SERVER="mssql" \
     DB_NAMES="" \
     CRON_SCHEDULE="0 1 * * sun" \
     BACKUP_CLEANUP=false \
-    BACKUP_AGE=7
+    BACKUP_AGE=7 \
+    SKIP_BACKUP_LOG=false 
 
 RUN apt-get update && \
     apt-get install -y cron && \

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ These environment variables are supported:
 | DB_NAMES             |               | Names of the databases for which a backup should be created.                                                                                                                                                                     |
 | TZ                   |               | Timezone to use.                                                                                                                                                                                                                 |
 | CRON_SCHEDULE        | `0 1 * * sun` | Cron schedule for running backups. NOTE: There is no check if there's already a backup running when starting the backup job. Therefore time interval needs to be longer than the maximum expected backup time for all databases. |
-| BACKUP_CLEANUP      | `false` | Set to "true" if you want to let the cronjob remove files older than $BACKUP_AGE days |
-| BACKUP_AGE          | `7` | Number of days to keep backups in backup directory |
+| BACKUP_CLEANUP       | `false`       | Set to "true" if you want to let the cronjob remove files older than $BACKUP_AGE days                                                                                                                                            |
+| BACKUP_AGE           | `7`           | Number of days to keep backups in backup directory                                                                                                                                                                               |
+| SKIP_BACKUP_LOG      | `false`       | Skip step to backup the transaction log .                                                                                                                                                                                         |
 
 ## Examples
 

--- a/backup.sh
+++ b/backup.sh
@@ -25,15 +25,19 @@ do
   fi
 
   # backup log files
-  TRN_FILENAME=/backup/$CURRENT_DATE.$CURRENT_DB.trn
+  if [ "$SKIP_BACKUP_LOG" = false ]; then
+    TRN_FILENAME=/backup/$CURRENT_DATE.$CURRENT_DB.trn
 
-  echo "Backup log of $CURRENT_DB to $TRN_FILENAME on $DB_SERVER..."
-  if /opt/mssql-tools/bin/sqlcmd -S "$DB_SERVER" -U "$DB_USER" -P "$DB_PASSWORD" -b -Q "BACKUP LOG [$CURRENT_DB] TO DISK = N'$TRN_FILENAME' WITH NOFORMAT, NOINIT, NAME = '$CURRENT_DB-log', SKIP, NOUNLOAD, STATS = 10"
-  then
-    echo "Backup of log successfully created"
+    echo "Backup log of $CURRENT_DB to $TRN_FILENAME on $DB_SERVER..."
+    if /opt/mssql-tools/bin/sqlcmd -S "$DB_SERVER" -U "$DB_USER" -P "$DB_PASSWORD" -b -Q "BACKUP LOG [$CURRENT_DB] TO DISK = N'$TRN_FILENAME' WITH NOFORMAT, NOINIT, NAME = '$CURRENT_DB-log', SKIP, NOUNLOAD, STATS = 10"
+    then
+      echo "Backup of log successfully created"
+    else
+      echo "Error creating log backup"
+      rm -rf "$TRN_FILENAME"
+    fi
   else
-    echo "Error creating log backup"
-    rm -rf "$TRN_FILENAME"
+    echo "Backup of log skipped."
   fi
 
   # cleanup old backup files


### PR DESCRIPTION
Support to disable backup of transaction logs.
Add environment variable `SKIP_BACKUP_LOG` to skip backup transaction log.