### PR TITLE
Create backups in $TARGETDIR instead of $WORKINGDIR

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -83,11 +83,11 @@ do
   # Push to remote directory
   if [ "$PUSH_REMOTE_MODE" = "move" ] || [ "$PUSH_REMOTE_MODE" = "copy" ]; then
     echo "Push backup to remote directory"
-    find $TARGETDIR -maxdepth 1 -type f -name "BACKUPNAME.*" -exec cp {} $REMOTEDIR \;
+    find $TARGETDIR -maxdepth 1 -type f -name "$BACKUPNAME.*" -exec cp {} $REMOTEDIR \;
 
     if [ "$PUSH_REMOTE_MODE" = "move" ]; then
       echo "Cleanup target directory"
-      find $TARGETDIR -maxdepth 1 -type f -name "BACKUPNAME.*" -exec rm {} \;
+      find $TARGETDIR -maxdepth 1 -type f -name "$BACKUPNAME.*" -exec rm {} \;
     fi
   fi
 


### PR DESCRIPTION
Because the backups are created in a working directory and moved, SSMS cannot find the backup files when using the Timeline to restore them. It looks for the backups in `/backup/<CURRENTDATE>/<BACKUPFILE>` instead of `/backup/<BACKUPFILE>` Obviously the backups can be found and restored by selecting 'Device' and finding the files manually, but being able to use the Timeline interface makes things nicer.

It does away with the working directly, and identifies the working files by their unique file name (CurrentDate.DatabaseName, which is stored in a variable called `$BACKUPNAME`). That way the backups can be created directly into the target dir and SSMS knows where they are. 

Testing:
- I've tested it working with `$PACK` disabled, and set to 'tar'. 
- I've also tested with `$SKIP_BACKUP_LOG` both true and false. 
- I have not tested with remote directory, but don't expect there will be any issues.
